### PR TITLE
Add option for font/stroke color

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ input        : input JSON filename - must be specified always
 --compact    : compact rendering mode
 --vspace     : vertical space - default 80
 --hspace     : horizontal space - default 640
---lanes      : rectangle lanes - default 2
+--lanes      : rectangle lanes - default 1
 --bits       : overall bitwidth - default 32
 --fontfamily : - default sans-serif
 --fontweight : - default normal
@@ -57,6 +57,7 @@ input        : input JSON filename - must be specified always
 
 --json5      : force json5 input format (need json5 python module)
 --no-json5   : never use json5 input format
+--fontcolor  : color to use for font and stroke. Hex code ("#000000") or name
 ```
 
 ### alpha.json

--- a/bit_field/cli.py
+++ b/bit_field/cli.py
@@ -1,4 +1,4 @@
-from .render import render
+from .render import render, DEFAULT_TXT_STROKE_COLOR
 from .jsonml_stringify import jsonml_stringify
 import argparse
 
@@ -34,6 +34,7 @@ def bit_field_cli():
     parser.add_argument('--trim', help='trim long bitfield names', type=float)
     parser.add_argument('--uneven', help='uneven lanes', action='store_true')
     parser.add_argument('--legend', help='legend item', action='append', nargs=2, metavar=('NAME', 'TYPE'))
+    parser.add_argument("--fontcolor", help='color to use for font and stroke. Hex code ("#000000") or name', default=DEFAULT_TXT_STROKE_COLOR)
     args = parser.parse_args()
 
     # default is json5, unless forced with --(no-)json5
@@ -63,7 +64,8 @@ def bit_field_cli():
                      strokewidth=args.strokewidth,
                      trim=args.trim,
                      uneven=args.uneven,
-                     legend={key: value for key, value in args.legend} if args.legend else None)
+                     legend={key: value for key, value in args.legend} if args.legend else None,
+                     fontcolor=args.fontcolor)
 
     res = jsonml_stringify(res)
     if args.beautify:

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -9,6 +9,8 @@ def t(x, y):
 def typeStyle(t):
     return ';fill:' + typeColor(t)
 
+# default color for text and stroke in diagram
+DEFAULT_TXT_STROKE_COLOR = "black"
 
 def typeColor(t):
     styles = {
@@ -42,7 +44,8 @@ class Renderer(object):
                  strokewidth=1,
                  trim=None,
                  uneven=False,
-                 legend=None):
+                 legend=None,
+                 fontcolor=DEFAULT_TXT_STROKE_COLOR):
         if vspace <= 19:
             raise ValueError(
                 'vspace must be greater than 19, got {}.'.format(vspace))
@@ -72,6 +75,7 @@ class Renderer(object):
         self.trim_char_width = trim
         self.uneven = uneven
         self.legend = legend
+        self.fontcolor = fontcolor
 
     def get_total_bits(self, desc):
         return sum(e['bits'] for e in desc)
@@ -148,6 +152,7 @@ class Renderer(object):
                 'font-family': self.fontfamily,
                 'font-weight': self.fontweight,
                 'y': self.fontsize / 1.2,
+                'fill': self.fontcolor,
             }, key])
             x += name_padding
         return items
@@ -175,7 +180,7 @@ class Renderer(object):
         else:
             dy = 0
         res = ['g', {
-            'stroke': 'black',
+            'stroke': self.fontcolor,
             'stroke-width': self.stroke_width,
             'stroke-linecap': 'butt',
             'transform': t(0, dy)
@@ -251,14 +256,16 @@ class Renderer(object):
                     'x': step * lsb_pos,
                     'font-size': self.fontsize,
                     'font-family': self.fontfamily,
-                    'font-weight': self.fontweight
+                    'font-weight': self.fontweight,
+                    'fill': self.fontcolor,
                 }, str(lsb)])
                 if lsbm != msbm:
                     bits.append(['text', {
                         'x': step * msb_pos,
                         'font-size': self.fontsize,
                         'font-family': self.fontfamily,
-                        'font-weight': self.fontweight
+                        'font-weight': self.fontweight,
+                        'fill': self.fontcolor,
                     }, str(msb)])
             if 'name' in e:
                 ltextattrs = {
@@ -266,7 +273,8 @@ class Renderer(object):
                     'font-family': self.fontfamily,
                     'font-weight': self.fontweight,
                     'text-anchor': 'middle',
-                    'y': 6
+                    'y': 6,
+                    'fill': self.fontcolor,
                 }
                 if 'rotate' in e:
                     ltextattrs['transform'] = ' rotate({})'.format(e['rotate'])
@@ -306,13 +314,15 @@ class Renderer(object):
                                 'font-size': self.fontsize,
                                 'font-family': self.fontfamily,
                                 'font-weight': self.fontweight,
+                                'fill': self.fontcolor,
                             }] + tspan(bit_text)]
                     else:
                         atext = [['text', {
                             'x': step * (msb_pos + lsb_pos) / 2,
                             'font-size': self.fontsize,
                             'font-family': self.fontfamily,
-                            'font-weight': self.fontweight
+                            'font-weight': self.fontweight,
+                            'fill': self.fontcolor,
                         }] + tspan(attribute)]
                     attrs.append(['g', {
                         'transform': t(0, i*self.fontsize)
@@ -325,6 +335,7 @@ class Renderer(object):
                         'font-size': self.fontsize,
                         'font-family': self.fontfamily,
                         'font-weight': self.fontweight,
+                        'fill': self.fontcolor,
                     }, str(i if self.vflip else self.mod - i - 1)])
             res = ['g', {}, bits, ['g', {
                 'transform': t(0, self.fontsize*1.2)

--- a/bit_field/test/.gitignore
+++ b/bit_field/test/.gitignore
@@ -1,0 +1,2 @@
+output-compare.html
+output-*/

--- a/bit_field/test/test_render.py
+++ b/bit_field/test/test_render.py
@@ -15,6 +15,7 @@ from .render_report import render_report
 @pytest.mark.parametrize('strokewidth', [1, 4])
 @pytest.mark.parametrize('trim', [None, 8])
 @pytest.mark.parametrize('uneven', [True])
+@pytest.mark.parametrize('fontcolor', ["black", "blue"])
 def test_render(request,
                 output_dir,
                 input_data,
@@ -25,7 +26,8 @@ def test_render(request,
                 vflip,
                 strokewidth,
                 trim,
-                uneven):
+                uneven,
+                fontcolor):
     res = render(input_data,
                  bits=bits,
                  lanes=lanes,
@@ -34,7 +36,8 @@ def test_render(request,
                  vflip=vflip,
                  strokewidth=strokewidth,
                  trim=trim,
-                 uneven=uneven)
+                 uneven=uneven,
+                 fontcolor=fontcolor)
     res[1]['data-bits'] = bits
     res[1]['data-lanes'] = lanes
     res[1]['data-compact'] = compact
@@ -43,6 +46,7 @@ def test_render(request,
     res[1]['data-strokewidth'] = strokewidth
     res[1]['data-trim'] = trim
     res[1]['data-uneven'] = uneven
+    res[1]['data-fontcolor'] = fontcolor
     res = jsonml_stringify(res)
 
     output_filename = request.node.name


### PR DESCRIPTION
Thanks for this great project! Continue to use this across multiple Sphinx doc projects. 

This PR adds an option for specifying the color to use for all outlines/strokes/fonts.

For instance running something like this:

`python -m bit_field --fontcolor "#FF4500" --lanes 2 readme_alpha.json`

will result in this SVG:

![orange_alpha](https://github.com/user-attachments/assets/78af403f-fec9-42f5-a95d-4c196890b159)

you can also use svg color names:

`python -m bit_field --fontcolor blue --lanes 2 readme_alpha.json`

![blue_alpha](https://github.com/user-attachments/assets/fa67865b-2239-47aa-b20b-1e93800b6b90)


And the default remains as black:

`python -m bit_field  --lanes 2 readme_alpha.json`

![default_alpha](https://github.com/user-attachments/assets/24dcff80-514d-4d00-9326-bda19c265cab)



I realize adding more functionality to something that's meant to be a direct port is not necessarily desirable. So i understand if you dont want to merge this in. I saw a need for this to make my bitfield diagrams more legible on dark-mode sites.